### PR TITLE
Add a boolean to cleanly exit sender thread

### DIFF
--- a/templates/microRTPS_agent.cpp.template
+++ b/templates/microRTPS_agent.cpp.template
@@ -310,4 +310,3 @@ int main(int argc, char** argv)
 
     return 0;
 }
-ArkadiuszNiemiec

--- a/templates/microRTPS_agent.cpp.template
+++ b/templates/microRTPS_agent.cpp.template
@@ -52,6 +52,7 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
  ****************************************************************************/
 
 #include <thread>
+#include <atomic>
 #include <unistd.h>
 #include <poll.h>
 #include <chrono>
@@ -180,8 +181,9 @@ void signal_handler(int signum)
    running = 0;
    transport_node->close();
 }
-@[if recv_topics]@
 
+@[if recv_topics]@
+std::atomic<bool> exit(false);
 void t_send(void *data)
 {
     char data_buffer[BUFFER_SIZE] = {};
@@ -191,7 +193,7 @@ void t_send(void *data)
     while (running)
     {
         // Send subscribed topics over UART
-        while (topics.hasMsg(&topic_ID))
+        while (topics.hasMsg(&topic_ID) && !exit.load())
         {
             uint16_t header_length = transport_node->get_header_length();
             /* make room for the header to fill in later */
@@ -300,6 +302,7 @@ int main(int argc, char** argv)
         usleep(_options.sleep_us);
     }
 @[if recv_topics]@
+    exit = true;
     sender_thread.join();
 @[end if]@
     delete transport_node;

--- a/templates/microRTPS_agent.cpp.template
+++ b/templates/microRTPS_agent.cpp.template
@@ -183,7 +183,7 @@ void signal_handler(int signum)
 }
 
 @[if recv_topics]@
-std::atomic<bool> exit(false);
+std::atomic<bool> exit_sender_thread(false);
 void t_send(void *data)
 {
     char data_buffer[BUFFER_SIZE] = {};
@@ -193,7 +193,7 @@ void t_send(void *data)
     while (running)
     {
         // Send subscribed topics over UART
-        while (topics.hasMsg(&topic_ID) && !exit.load())
+        while (topics.hasMsg(&topic_ID) && !exit_sender_thread.load())
         {
             uint16_t header_length = transport_node->get_header_length();
             /* make room for the header to fill in later */
@@ -302,7 +302,7 @@ int main(int argc, char** argv)
         usleep(_options.sleep_us);
     }
 @[if recv_topics]@
-    exit = true;
+    exit_sender_thread = true;
     sender_thread.join();
 @[end if]@
     delete transport_node;
@@ -310,3 +310,4 @@ int main(int argc, char** argv)
 
     return 0;
 }
+ArkadiuszNiemiec


### PR DESCRIPTION
This PR is intended to fix a #28. I have added a boolean that is set when the main thread exits and allows the `t_send()` to leave a loop and thus allows `sender_thread.join();` to finish.

I have used a `std::atomic<bool>` variable but if you don't like the `std::atomic` I can change it to normal `bool`.