### PR TITLE
scripts: fix computing script directory

### DIFF
--- a/scripts/build_all.bash
+++ b/scripts/build_all.bash
@@ -15,7 +15,10 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
   exit 0
 fi
 
-SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+SCRIPT_DIR=$0
+if [[ ${SCRIPT_DIR:0:1} != '/' ]]; then
+  SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+fi
 
 # parse the arguments
 while [ $# -gt 0 ]; do

--- a/scripts/build_ros1_bridge.bash
+++ b/scripts/build_ros1_bridge.bash
@@ -17,7 +17,10 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
   exit 0
 fi
 
-SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+SCRIPT_DIR=$0
+if [[ ${SCRIPT_DIR:0:1} != '/' ]]; then
+  SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+fi
 
 # parse the arguments
 while [ $# -gt 0 ]; do

--- a/scripts/build_ros2_workspace.bash
+++ b/scripts/build_ros2_workspace.bash
@@ -13,7 +13,10 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
   exit 0
 fi
 
-SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+SCRIPT_DIR=$0
+if [[ ${SCRIPT_DIR:0:1} != '/' ]]; then
+  SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+fi
 
 # parse the arguments
 while [ $# -gt 0 ]; do

--- a/scripts/clean_all.bash
+++ b/scripts/clean_all.bash
@@ -12,7 +12,10 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
   exit 0
 fi
 
-SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+SCRIPT_DIR=$0
+if [[ ${SCRIPT_DIR:0:1} != '/' ]]; then
+  SCRIPT_DIR=$(dirname $(realpath -s "$PWD/$0"))
+fi
 
 # parse the arguments
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
Apparently, $0 sometimes contains an absolute path instead of the
usual relative path to the script.