### PR TITLE
Fixed ament deprecation warning for foxy and later.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ else()
   message(FATAL_ERROR "No ROS Distro set")
 endif()
 
+set(USES_DEPRECATD_EXPORT_API "dashing" "eloquent")
+
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(fastcdr REQUIRED)
@@ -104,7 +106,12 @@ if(ROS_DISTRO IN_LIST ROS_DISTROS)
 else()
   ament_export_dependencies(ament_cmake rclcpp rosidl_default_runtime Eigen3 px4_msgs geometry_msgs sensor_msgs)
 endif()
-ament_export_interfaces(export_frame_transforms HAS_LIBRARY_TARGET)
+if (ROS_DISTRO IN_LIST USES_DEPRECATED_EXPORT_API)
+  ament_export_interfaces(export_frame_transforms HAS_LIBRARY_TARGET)
+else()
+	ament_export_targets(export_frame_transforms HAS_LIBRARY_TARGET)
+endif()	  
+
 ament_export_include_directories(include)
 ament_export_libraries(frame_transforms)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
   message(FATAL_ERROR "No ROS Distro set")
 endif()
 
-set(USES_DEPRECATD_EXPORT_API "dashing" "eloquent")
+set(USES_DEPRECATD_EXPORT_API "ardent" "bouncy" "crystal" "dashing" "eloquent")
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 if (ROS_DISTRO IN_LIST USES_DEPRECATED_EXPORT_API)
   ament_export_interfaces(export_frame_transforms HAS_LIBRARY_TARGET)
 else()
-	ament_export_targets(export_frame_transforms HAS_LIBRARY_TARGET)
+  ament_export_targets(export_frame_transforms HAS_LIBRARY_TARGET)
 endif()	  
 
 ament_export_include_directories(include)


### PR DESCRIPTION
This change fixes the deprecation warning when building against Foxy (and later).

In earlier ros2 distro's, `ament_export_interface` was used to export some library features, but was changed earlier this year (see https://github.com/ament/ament_cmake/issues/237) to instead use `ament_export_targets`.

A guard was added to use the old API for eloquent and dashing (which I'm assuming are the only older supported distros) and default to new one for all others.