### PR TITLE
Timestamp sample offset for messages with it

### DIFF
--- a/templates/RtpsTopics.cpp.em
+++ b/templates/RtpsTopics.cpp.em
@@ -141,8 +141,99 @@ bool RtpsTopics::getMsg(const uint8_t topic_ID, eprosima::fastcdr::Cdr &scdr)
 @[    end if]@
                 // apply timestamp offset
                 uint64_t timestamp = getMsgTimestamp(&msg);
+@[    if topic == 'VehicleOdometry' \
+          or topic == 'VehicleMocapOdometry' \
+          or topic == 'VehicleVisualOdometry' \
+          or topic == 'VehicleVisionAttitude' \
+          or topic == 'WindEstimate' \
+          or topic == 'YawEstimatorStatus' \
+          or topic == 'VehicleVisionAttitude' \
+          or topic == 'ActuatorControls' \
+          or topic == 'ActuatorControls0' \
+          or topic == 'ActuatorControls1' \
+          or topic == 'ActuatorControls2' \
+          or topic == 'ActuatorControls3' \
+          or topic == 'ActuatorControlsVirtualFw' \
+          or topic == 'ActuatorControlsVirtualMc' \
+          or topic == 'EstimatorAttitude' \
+          or topic == 'EstimatorGlobalPosition' \
+          or topic == 'EstimatorInnovations' \
+          or topic == 'EstimatorInnovationTestRatios' \
+          or topic == 'EstimatorInnovationVariances' \
+          or topic == 'EstimatorLocalPosition' \
+          or topic == 'EstimatorOdometry' \
+          or topic == 'EstimatorOpticalFlowVel' \
+          or topic == 'EstimatorSensorBias' \
+          or topic == 'EstimatorStates' \
+          or topic == 'EstimatorStatus' \
+          or topic == 'EstimatorVisualOdometryAligned' \
+          or topic == 'HoverThrustEstimate' \
+          or topic == 'SensorAccel' \
+          or topic == 'SensorAccelFifo' \
+          or topic == 'SensorMag' \
+          or topic == 'VehicleAcceleration' \
+          or topic == 'VehicleAirData' \
+          or topic == 'VehicleAngularAcceleration' \
+          or topic == 'VehicleAngularVelocity' \
+          or topic == 'VehicleAngularVelocityGroundtruth' \
+          or topic == 'VehicleAttitude' \
+          or topic == 'VehicleAttitudeGroundtruth' \
+          or topic == 'VehicleGlobalPosition' \
+          or topic == 'VehicleGlobalPositionGroundtruth' \
+          or topic == 'VehicleImu' \
+          or topic == 'VehicleLocalPosition' \
+          or topic == 'VehicleLocalPositionGroundtruth' \
+          or topic == 'VehicleMagnetometer']@
+                uint64_t timestamp_sample = getMsgTimestampSample(&msg);
+@[    end if]@
                 _timesync->addOffset(timestamp);
                 setMsgTimestamp(&msg, timestamp);
+@[    if topic == 'VehicleOdometry' \
+          or topic == 'VehicleMocapOdometry' \
+          or topic == 'VehicleVisualOdometry' \
+          or topic == 'VehicleVisionAttitude' \
+          or topic == 'WindEstimate' \
+          or topic == 'YawEstimatorStatus' \
+          or topic == 'VehicleVisionAttitude' \
+          or topic == 'ActuatorControls' \
+          or topic == 'ActuatorControls0' \
+          or topic == 'ActuatorControls1' \
+          or topic == 'ActuatorControls2' \
+          or topic == 'ActuatorControls3' \
+          or topic == 'ActuatorControlsVirtualFw' \
+          or topic == 'ActuatorControlsVirtualMc' \
+          or topic == 'EstimatorAttitude' \
+          or topic == 'EstimatorGlobalPosition' \
+          or topic == 'EstimatorInnovations' \
+          or topic == 'EstimatorInnovationTestRatios' \
+          or topic == 'EstimatorInnovationVariances' \
+          or topic == 'EstimatorLocalPosition' \
+          or topic == 'EstimatorOdometry' \
+          or topic == 'EstimatorOpticalFlowVel' \
+          or topic == 'EstimatorSensorBias' \
+          or topic == 'EstimatorStates' \
+          or topic == 'EstimatorStatus' \
+          or topic == 'EstimatorVisualOdometryAligned' \
+          or topic == 'HoverThrustEstimate' \
+          or topic == 'SensorAccel' \
+          or topic == 'SensorAccelFifo' \
+          or topic == 'SensorMag' \
+          or topic == 'VehicleAcceleration' \
+          or topic == 'VehicleAirData' \
+          or topic == 'VehicleAngularAcceleration' \
+          or topic == 'VehicleAngularVelocity' \
+          or topic == 'VehicleAngularVelocityGroundtruth' \
+          or topic == 'VehicleAttitude' \
+          or topic == 'VehicleAttitudeGroundtruth' \
+          or topic == 'VehicleGlobalPosition' \
+          or topic == 'VehicleGlobalPositionGroundtruth' \
+          or topic == 'VehicleImu' \
+          or topic == 'VehicleLocalPosition' \
+          or topic == 'VehicleLocalPositionGroundtruth' \
+          or topic == 'VehicleMagnetometer']@
+                _timesync->addOffset(timestamp_sample);
+                setMsgTimestampSample(&msg, timestamp_sample);
+@[    end if]@
                 msg.serialize(scdr);
                 ret = true;
 @[    if topic == 'Timesync' or topic == 'timesync']@

--- a/templates/RtpsTopics.h.em
+++ b/templates/RtpsTopics.h.em
@@ -122,6 +122,9 @@ private:
     inline uint64_t getMsgTimestamp(const T* msg) { return msg->timestamp_(); }
 
     template <class T>
+    inline uint64_t getMsgTimestampSample(const T* msg) { return msg->timestamp_sample_(); }
+
+    template <class T>
     inline uint8_t getMsgSysID(const T* msg) { return msg->sys_id_(); }
 
     template <class T>
@@ -129,6 +132,9 @@ private:
 @[elif ros2_distro]@
     template <class T>
     inline uint64_t getMsgTimestamp(const T* msg) { return msg->timestamp(); }
+
+    template <class T>
+    inline uint64_t getMsgTimestampSample(const T* msg) { return msg->timestamp_sample(); }
 
     template <class T>
     inline uint8_t getMsgSysID(const T* msg) { return msg->sys_id(); }
@@ -143,6 +149,9 @@ private:
     inline void setMsgTimestamp(T* msg, const uint64_t& timestamp) { msg->timestamp_() = timestamp; }
 
     template <class T>
+    inline void setMsgTimestampSample(T* msg, const uint64_t& timestamp_sample) { msg->timestamp_sample_() = timestamp_sample; }
+
+    template <class T>
     inline void setMsgSysID(T* msg, const uint8_t& sys_id) { msg->sys_id_() = sys_id; }
 
     template <class T>
@@ -150,6 +159,9 @@ private:
 @[elif ros2_distro]@
     template <class T>
     inline void setMsgTimestamp(T* msg, const uint64_t& timestamp) { msg->timestamp() = timestamp; }
+
+    template <class T>
+    inline void setMsgTimestampSample(T* msg, const uint64_t& timestamp_sample) { msg->timestamp_sample() = timestamp_sample; }
 
     template <class T>
     inline void setMsgSysID(T* msg, const uint8_t& sys_id) { msg->sys_id() = sys_id; }


### PR DESCRIPTION
This needed to use corresponding messages in PX4<->ROS interaction. Without `timestamp_sample` synchronization PX4 modules will discard it.