### PR TITLE
fix timesync for timestamp sample (including SFINAE detection)

### DIFF
--- a/templates/RtpsTopics.cpp.em
+++ b/templates/RtpsTopics.cpp.em
@@ -111,6 +111,9 @@ void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
             uint64_t timestamp = getMsgTimestamp(&st);
             _timesync->subtractOffset(timestamp);
             setMsgTimestamp(&st, timestamp);
+            uint64_t timestamp_sample = getMsgTimestampSample(&st);
+            _timesync->subtractOffset(timestamp_sample);
+            setMsgTimestampSample(&st, timestamp_sample);
             _@(topic)_pub.publish(&st);
 @[    if topic == 'Timesync' or topic == 'timesync']@
             }

--- a/templates/RtpsTopics.h.em
+++ b/templates/RtpsTopics.h.em
@@ -120,10 +120,13 @@ private:
     // SFINAE
     template<typename T> struct hasTimestampSample{
     private:
-      static void detect(...);
-      template<typename U> static decltype(std::declval<U>().timestamp_sample()) detect(const U&);
+        template<typename U,
+                typename = decltype(std::declval<U>().timestamp_sample(int64_t()))>
+        static std::true_type detect(int);
+        template<typename U>
+        static std::false_type detect(...);
     public:
-      static constexpr bool value = std::is_same<uint64_t, decltype(detect(std::declval<T>()))>::value;
+        static constexpr bool value = decltype(detect<T>(0))::value;
     };
 
     template<typename T>


### PR DESCRIPTION
This PR fixes the SFINAE detection for timestamp_sample member in RTPS topics (the previous version was always returning false, whatever the topic).

It also fixes a missing part of the code to ensure the time synchronization of the timestamp samples.