### PR TITLE
add missing header for PRIu32 and PRIu16 macros

### DIFF
--- a/templates/microRTPS_transport.cpp
+++ b/templates/microRTPS_transport.cpp
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <cstdlib>
+#include <inttypes.h>
 #if __has_include("px4_platform_common/log.h") && __has_include("px4_platform_common/time.h")
 #include <px4_platform_common/log.h>
 #include <px4_platform_common/time.h>


### PR DESCRIPTION
Build fails with the following message:
```
Starting >>> px4_ros_com                                                                                                                                                                                                                                                                  
--- stderr: px4_ros_com                                                                                                                                                                                                                                                                   
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp: In member function ‘ssize_t Transport_node::read(uint8_t*, char*, size_t)’:                                                                                    
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:153:99: error: expected ‘)’ before ‘PRIu32’                                                                                                                     
  153 |   if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓↓ %" PRIu32 ")\033[0m\n", msg_start_pos);                                                                                                                                               
      |                    ~                                                                              ^~~~~~~                                                                                                                                                                         
      |                                                                                                   )                                                                                                                                                                               
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:153:97: warning: spurious trailing ‘%’ in format [-Wformat=]                                                                                                    
  153 |   if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓↓ %" PRIu32 ")\033[0m\n", msg_start_pos);                                                                                                                                               
      |                                                                                                 ^                                                                                                                                                                                 
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:153:21: warning: too many arguments for format [-Wformat-extra-args]                                                                                            
  153 |   if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓↓ %" PRIu32 ")\033[0m\n", msg_start_pos);                                                                                                                                               
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:181:97: error: expected ‘)’ before ‘PRIu32’                                                                                                                     
  181 |    if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓ %" PRIu32 ")\033[0m\n", msg_start_pos);                                                                                                                                               
      |                     ~                                                                           ^~~~~~~                                                                                                                                                                           
      |                                                                                                 )                                                                                                                                                                                 
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:181:95: warning: spurious trailing ‘%’ in format [-Wformat=]                                                                                                    
  181 |    if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓ %" PRIu32 ")\033[0m\n", msg_start_pos);                                                                                                                                               
      |                                                                                               ^                                                                                                                                                                                   
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:181:22: warning: too many arguments for format [-Wformat-extra-args]                                                                                            
  181 |    if (debug) printf("\033[1;33m[ micrortps_transport ]\t                                (↓ %" PRIu32 ")\033[0m\n", msg_start_pos);                                                                                                                                               
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                  
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:197:67: error: expected ‘)’ before ‘PRIu16’                                                                                                                     
  197 |   if (debug) printf("\033[0;31m[ micrortps_transport ]\tBad CRC %" PRIu16 " != %" PRIu16 "\t\t(↓ %lu)\033[0m\n", read_crc, calc_crc, (unsigned long)(header_size + payload_len));                                                                                                 
      |                    ~                                              ^~~~~~~                                                                                                                                                                                                         
      |                                                                   )                                                                                                                                                                                                               
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:197:65: warning: spurious trailing ‘%’ in format [-Wformat=]                                                                                                    
  197 |   if (debug) printf("\033[0;31m[ micrortps_transport ]\tBad CRC %" PRIu16 " != %" PRIu16 "\t\t(↓ %lu)\033[0m\n", read_crc, calc_crc, (unsigned long)(header_size + payload_len));                                                                                                 
      |                                                                 ^                                                                                                                                                                                                                 
/home/seulbae/workspace/ros-security/targets/px4_ros_com_ros2/src/px4_ros_com/src/micrortps_agent/microRTPS_transport.cpp:197:21: warning: too many arguments for format [-Wformat-extra-args]                                                                                            
  197 |   if (debug) printf("\033[0;31m[ micrortps_transport ]\tBad CRC %" PRIu16 " != %" PRIu16 "\t\t(↓ %lu)\033[0m\n", read_crc, calc_crc, (unsigned long)(header_size + payload_len));                                                                                                 
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                   
make[2]: *** [CMakeFiles/micrortps_agent.dir/build.make:576: CMakeFiles/micrortps_agent.dir/src/micrortps_agent/microRTPS_transport.cpp.o] Error 1                                                                                                                                        
make[2]: *** Waiting for unfinished jobs....                                                                                                                                                                                                                                              
make[1]: *** [CMakeFiles/Makefile2:142: CMakeFiles/micrortps_agent.dir/all] Error 2                                                                                                                                                                                                       
make: *** [Makefile:141: all] Error 2                                                                                                        
---                                                                                                                                                                                                                                                                                       
Failed   <<< px4_ros_com [3.54s, exited with code 2]                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                          
Summary: 1 package finished [25.5s]                                                                                                                                                                                                                                                       
  1 package failed: px4_ros_com                                                                                                                                                                                                                                                           
  1 package had stderr output: px4_ros_com  
```

This PR fixes the error by including `inttypes.h` to the template file.