### PR TITLE
build_ros1_bridge: source devel/setup.bash

### DIFF
--- a/scripts/build_ros1_bridge.bash
+++ b/scripts/build_ros1_bridge.bash
@@ -143,7 +143,9 @@ if [ -z $ROS1_WS_DIR ]; then
   echo "ROS1 workspace does not exist!"
   exit 1
 else
-  if [ -f $ROS1_WS_DIR/install/setup.bash ]; then
+  if [ -f $ROS1_WS_DIR/devel/setup.bash ]; then
+    unset ROS_DISTRO && source $ROS1_WS_DIR/devel/setup.bash
+  elif [ -f $ROS1_WS_DIR/install/setup.bash ]; then
     unset ROS_DISTRO && source $ROS1_WS_DIR/install/setup.bash
   else
     echo "ROS1 workspace not built."


### PR DESCRIPTION
I am doing most ROS1 stuff only in the devel environment. Just like in build_all, this allows to build the ros1 bridge without having `install` configured.