### PR TITLE
fix script error when there is no default ros installation and the ro…

### DIFF
--- a/scripts/build_ros2_workspace.bash
+++ b/scripts/build_ros2_workspace.bash
@@ -71,6 +71,7 @@ if [ -z $ros_distro ]; then
       else
         # source the ROS2 environment (from arg)
         source $ros_path
+        ros_path_sourced=1
       fi
     fi
     ;;
@@ -89,6 +90,7 @@ if [ -z $ros_distro ]; then
       else
         # source the ROS2 environment (from arg)
         source $ros_path
+        ros_path_sourced=1
       fi
     fi
     ;;
@@ -97,8 +99,11 @@ if [ -z $ros_distro ]; then
     exit 1
     ;;
   esac
-  # source the ROS2 environment
-  source /opt/ros/$ROS_DISTRO/setup.bash
+  # source only if not already sourced from ros_path
+  if [ -z $ros_path_sourced ]; then
+    # source the ROS2 environment
+    source /opt/ros/$ROS_DISTRO/setup.bash
+  fi
 else
   if [ -z $ros_path ]; then
     echo "- Warning: You set a ROS 2 manually to be used."


### PR DESCRIPTION
…s_path argument is used:

  source ./build_ros2_workspace.bash --ros_path /home/sylvain/work/ros/foxy/install/setup.bash
  ./build_ros2_workspace.bash: line 101: /opt/ros/foxy/setup.bash: No such file or directory

  2 consecutive calls to the "source":
    - 1st line 91:  source $ros_path (ROS2 environment from arg)
    - 2nd line 101: source /opt/ros/$ROS_DISTRO/setup.bash
      In this second case, if there is no ROS installation, the script fails.