### PR TITLE
Match message definition for TrajectorySetpoint

### DIFF
--- a/src/examples/offboard/offboard_control.cpp
+++ b/src/examples/offboard/offboard_control.cpp
@@ -172,9 +172,7 @@ void OffboardControl::publish_offboard_control_mode() const {
 void OffboardControl::publish_trajectory_setpoint() const {
 	TrajectorySetpoint msg{};
 	msg.timestamp = timestamp_.load();
-	msg.x = 0.0;
-	msg.y = 0.0;
-	msg.z = -5.0;
+	msg.position = {0.0, 0.0, -5.0};
 	msg.yaw = -3.14; // [-PI:PI]
 
 	trajectory_setpoint_publisher_->publish(msg);


### PR DESCRIPTION
https://github.com/PX4/px4_msgs/commit/f78ecfcd47f833cffdace19d169a7eff37a383d0 updated the message definitions for [TrajectorySetpoint](https://github.com/PX4/px4_msgs/commit/f78ecfcd47f833cffdace19d169a7eff37a383d0#diff-34d4796f6e123228ed5ea1fa313ed4e0b3021b0aa9ac31172b57e2010b730540), which is used in offboard_control example.
Since the example is included in the build proccess (shown below), it causes the colcon build to fail.
https://github.com/PX4/px4_ros_com/blob/c99731363e92f95b9894dcec203d7ceaa71f599d/CMakeLists.txt#L99
Currently, this is causing the [Build ROS 2 Workspace](https://docs.px4.io/v1.12/en/ros/ros2_comm.html#build-ros-2-workspace) step in the PX4 ROS 2 documentation to fail.