### PR TITLE
scripts updated for ROS2 humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(EnableSanitizers)
 # Required since
 #   - "create_subscription()" and "create_publisher()" APIs changed
 #   - eigen3_cmake_module is only available in these distros
-list(APPEND ROS_DISTROS "dashing" "eloquent" "foxy" "galactic" "rolling")
+list(APPEND ROS_DISTROS "dashing" "eloquent" "foxy" "galactic" "humble" "rolling")
 set(ROS_DISTRO)
 if(DEFINED ENV{ROS2_DISTRO})
   set(ROS_DISTRO $ENV{ROS2_DISTRO})

--- a/scripts/build_all.bash
+++ b/scripts/build_all.bash
@@ -7,7 +7,7 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
   echo
   echo -e "\t--ros1_ws_dir \t\t Location of the ROS (1) workspace where one has cloned px4_ros_com 'ros1' branch. Default: $HOME/px4_ros_com_ros1"
   echo -e "\t--ros1_distro \t\t Set ROS (1) distro name (melodic|noetic). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
-  echo -e "\t--ros2_distro \t\t Set ROS 2 distro name (dashing|eloquent|foxy|galactic|rolling). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
+  echo -e "\t--ros2_distro \t\t Set ROS 2 distro name (dashing|eloquent|foxy|galactic|humble|rolling). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
   echo -e "\t--ros1_path \t\t Set ROS (1) environment setup.bash location. Useful for source installs. If not set, the script sources the environment in /opt/ros/$ROS_DISTRO/"
   echo -e "\t--ros2_path \t\t Set ROS 2 environment setup.bash location. Useful for source installs. If not set, the script sources the environment in /opt/ros/$ROS_DISTRO/"
   echo -e "\t--verbose \t\t Add more verbosity to the console output"
@@ -114,6 +114,32 @@ if [ -z $ros1_distro ] && [ -z $ros2_distro]; then
       if [ -z $ros2_path ]; then
         echo "- No ROS 2 distro installed or not installed in the default directory."
         echo "  If you are using a ROS 2 version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/foxy/install). Otherwise, please install ROS 2 Foxy following https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Binary/"
+        exit 1
+      else
+        # source the ROS2 environment (from arg)
+        source $ros2_path
+        export ROS2_DISTRO="$(rosversion -d)"
+      fi
+    fi
+    ;;
+  "jammy")
+    if [ -z $ros1_path ]; then
+      echo "- No ROS (1) distro installed."
+      echo "  If you are using a ROS (1) version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/noetic/install)."
+      exit 1
+    else
+      # source the ROS (1) environment (from arg)
+      source $ros1_path
+      export ROS1_DISTRO="$(rosversion -d)"
+    fi
+    if [ -d "/opt/ros/humble" ]; then
+      ROS2_DISTRO="humble"
+    elif [ -d "/opt/ros/rolling" ]; then
+      ROS2_DISTRO="rolling"
+    else
+      if [ -z $ros2_path ]; then
+        echo "- No ROS 2 distro installed or not installed in the default directory."
+        echo "  If you are using a ROS 2 version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/humble/install). Otherwise, please install ROS 2 Humble following https://docs.ros.org/en/humble/Installation.html"
         exit 1
       else
         # source the ROS2 environment (from arg)

--- a/scripts/build_ros1_bridge.bash
+++ b/scripts/build_ros1_bridge.bash
@@ -9,7 +9,7 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
   echo
   echo -e "\t--ros1_ws_dir \t Location of the ROS( 1) workspace where one has cloned px4_ros_com 'ros1' branch. Default: $HOME/px4_ros_com_ros1"
   echo -e "\t--ros1_distro \t Set ROS (1) distro name (melodic|noetic). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
-  echo -e "\t--ros2_distro \t Set ROS2  distro name (dashing|eloquent|foxy|galactic|rolling). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
+  echo -e "\t--ros2_distro \t Set ROS2  distro name (dashing|eloquent|foxy|galactic|humble|rolling). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
   echo -e "\t--ros1_path \t\t Set ROS(1) environment setup.bash location. Useful for source installs. If not set, the script sources the environment in /opt/ros/$ROS_DISTRO/"
   echo -e "\t--ros2_path \t\t Set ROS2 environment setup.bash location. Useful for source installs. If not set, the script sources the environment in /opt/ros/$ROS_DISTRO/"
   echo -e "\t--verbose \t\t Add more verbosity to the console output"
@@ -96,6 +96,32 @@ if [ -z $ros1_distro ] && [ -z $ros2_distro]; then
       if [ -z $ros2_path ]; then
         echo "- No ROS 2 distro installed or not installed in the default directory."
         echo "  If you are using a ROS 2 version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/foxy/install). Otherwise, please install ROS 2 Foxy following https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Binary/"
+        exit 1
+      else
+        # source the ROS2 environment (from arg)
+        source $ros2_path
+        export ROS2_DISTRO="$(rosversion -d)"
+      fi
+    fi
+    ;;
+  "jammy")
+    if [ -z $ros1_path ]; then
+      echo "- No ROS (1) distro installed."
+      echo "  If you are using a ROS (1) version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/noetic/install)."
+      exit 1
+    else
+      # source the ROS (1) environment (from arg)
+      source $ros1_path
+      export ROS1_DISTRO="$(rosversion -d)"
+    fi
+    if [ -d "/opt/ros/humble" ]; then
+      ROS2_DISTRO="humble"
+    elif [ -d "/opt/ros/rolling" ]; then
+      ROS2_DISTRO="rolling"
+    else
+      if [ -z $ros2_path ]; then
+        echo "- No ROS 2 distro installed or not installed in the default directory."
+        echo "  If you are using a ROS 2 version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/humble/install). Otherwise, please install ROS 2 Humble following https://docs.ros.org/en/humble/Installation.html"
         exit 1
       else
         # source the ROS2 environment (from arg)

--- a/scripts/build_ros2_workspace.bash
+++ b/scripts/build_ros2_workspace.bash
@@ -79,8 +79,6 @@ if [ -z $ros_distro ]; then
       ROS_DISTRO="foxy"
     elif [ -d "/opt/ros/galactic" ]; then
       ROS_DISTRO="galactic"
-    elif [ -d "/opt/ros/humble" ]; then
-      ROS_DISTRO="humble"
     elif [ -d "/opt/ros/rolling" ]; then
       ROS_DISTRO="rolling"
     else
@@ -102,7 +100,7 @@ if [ -z $ros_distro ]; then
     else
       if [ -z $ros_path ]; then
         echo "- No ROS 2 distro installed or not installed in the default directory."
-        echo "  If you are using a ROS 2 version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/foxy/install). Otherwise, please install ROS 2 Foxy following https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Binary/"
+        echo "  If you are using a ROS 2 version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/foxy/install). Otherwise, please install ROS 2 Humble following https://docs.ros.org/en/humble/Installation.html"
         exit 1
       else
         # source the ROS2 environment (from arg)

--- a/scripts/build_ros2_workspace.bash
+++ b/scripts/build_ros2_workspace.bash
@@ -6,7 +6,7 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
   echo -e "Usage: build_ros2_workspace.bash [option...] \t This script builds px4_ros_com workspace for ROS 2" >&2
   echo
   echo -e "\t--add_ros1_bridge \t Clone ros1_bridge. To be used in a further build in case a ROS1 workspace is used. Check 'build_all' or 'build_ros1_bridge' scripts."
-  echo -e "\t--ros_distro \t\t Set ROS 2 distro name (dashing|eloquent|foxy|galactic|rolling). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
+  echo -e "\t--ros_distro \t\t Set ROS 2 distro name (dashing|eloquent|foxy|galactic|humble|rolling). If not set, the script will set the ROS_DISTRO env variable based on the Ubuntu codename"
   echo -e "\t--ros_path \t\t Set ROS 2 environment setup.bash location. Useful for source installs. If not set, the script sources the environment in /opt/ros/$ROS_DISTRO"
   echo -e "\t--verbose \t\t Add more verbosity to the console output"
   echo
@@ -79,6 +79,24 @@ if [ -z $ros_distro ]; then
       ROS_DISTRO="foxy"
     elif [ -d "/opt/ros/galactic" ]; then
       ROS_DISTRO="galactic"
+    elif [ -d "/opt/ros/humble" ]; then
+      ROS_DISTRO="humble"
+    elif [ -d "/opt/ros/rolling" ]; then
+      ROS_DISTRO="rolling"
+    else
+      if [ -z $ros_path ]; then
+        echo "- No ROS 2 distro installed or not installed in the default directory."
+        echo "  If you are using a ROS 2 version installed from source, please set the install location with '--ros1_path' arg! (ex: ~/ros_src/foxy/install). Otherwise, please install ROS 2 Foxy following https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Install-Binary/"
+        exit 1
+      else
+        # source the ROS2 environment (from arg)
+        source $ros_path
+      fi
+    fi
+    ;;
+  "jammy")
+    if [ -d "/opt/ros/humble" ]; then
+      ROS_DISTRO="humble"
     elif [ -d "/opt/ros/rolling" ]; then
       ROS_DISTRO="rolling"
     else

--- a/scripts/generate_microRTPS_bridge.py
+++ b/scripts/generate_microRTPS_bridge.py
@@ -354,7 +354,7 @@ def generate_agent(out_dir):
     # the '-typeros2' option in fastrtpsgen.
     # .. note:: This is only available in FastRTPSGen 1.0.4 and above
     gen_ros2_typename = ""
-    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy', 'galactic', 'rolling'] and fastrtpsgen_version >= version.Version("1.0.4"):
+    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy', 'galactic', 'humble', 'rolling'] and fastrtpsgen_version >= version.Version("1.0.4"):
         gen_ros2_typename = "-typeros2 "
 
     idl_files = []

--- a/scripts/generate_microRTPS_bridge.py
+++ b/scripts/generate_microRTPS_bridge.py
@@ -354,7 +354,7 @@ def generate_agent(out_dir):
     # the '-typeros2' option in fastrtpsgen.
     # .. note:: This is only available in FastRTPSGen 1.0.4 and above
     gen_ros2_typename = ""
-    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy', 'galactic', 'humble', 'rolling'] and fastrtpsgen_version >= version.Version("1.0.4"):
+    if ros2_distro and ros2_distro in ['dashing', 'eloquent', 'foxy', 'galactic', 'rolling'] and fastrtpsgen_version >= version.Version("1.0.4"):
         gen_ros2_typename = "-typeros2 "
 
     idl_files = []


### PR DESCRIPTION
Updated scripts to support building with ROS2 humble and Ubuntu 22.04.

The scripts related to both ROS1 and ROS2 are not updated because there is no supported version of ROS1 for Ubuntu 22.04.

The changes were tested with SITL in jMAVsim.