### PR TITLE
Fixed fastrtps version reading in microRTPS generation for ROS2 built from sources

### DIFF
--- a/scripts/generate_microRTPS_bridge.py
+++ b/scripts/generate_microRTPS_bridge.py
@@ -206,9 +206,14 @@ if not ros2_distro:
     fastrtps_version = subprocess.check_output(
         "ldconfig -v 2>/dev/null | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
 else:
-    # grab the version of the ros-<ros_distro>-fastrtps package
-    fastrtps_version = re.search(r'Version:\s*([\dd.]+)', subprocess.check_output(
-        "dpkg -s ros-" + ros2_distro + "-fastrtps 2>/dev/null | grep -i version", shell=True).decode("utf-8").strip()).group(1)
+    try:
+        # grab the version of the ros-<ros_distro>-fastrtps package
+        fastrtps_version = re.search(r'Version:\s*([\dd.]+)', subprocess.check_output(
+            "dpkg -s ros-" + ros2_distro + "-fastrtps 2>/dev/null | grep -i version", shell=True).decode("utf-8").strip()).group(1)
+    except subprocess.CalledProcessError:
+        # if ROS2 was installed from sources the command above fails, get the system-wide version instead
+        fastrtps_version = subprocess.check_output(
+            "ldconfig -v 2>/dev/null | grep libfastrtps", shell=True).decode("utf-8").strip().split('so.')[-1]
 
 
 # If nothing specified it's generated both


### PR DESCRIPTION
When ROS2 is built from sources the dpkg check of fastrtps version was failing and stopping microRTPS bridge generation. After fix, in such a case, the system-wide version will be used