### PR TITLE
example listeners: fix QoS profile

### DIFF
--- a/src/examples/listeners/sensor_combined_listener.cpp
+++ b/src/examples/listeners/sensor_combined_listener.cpp
@@ -50,7 +50,10 @@ class SensorCombinedListener : public rclcpp::Node
 public:
 	explicit SensorCombinedListener() : Node("sensor_combined_listener")
 	{
-		subscription_ = this->create_subscription<px4_msgs::msg::SensorCombined>("/fmu/out/sensor_combined", 10,
+		rmw_qos_profile_t qos_profile = rmw_qos_profile_sensor_data;
+		auto qos = rclcpp::QoS(rclcpp::QoSInitialization(qos_profile.history, 5), qos_profile);
+		
+		subscription_ = this->create_subscription<px4_msgs::msg::SensorCombined>("/fmu/out/sensor_combined", qos,
 		[this](const px4_msgs::msg::SensorCombined::UniquePtr msg) {
 			std::cout << "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n";
 			std::cout << "RECEIVED SENSOR COMBINED DATA"   << std::endl;

--- a/src/examples/listeners/vehicle_gps_position_listener.cpp
+++ b/src/examples/listeners/vehicle_gps_position_listener.cpp
@@ -48,7 +48,10 @@ class VehicleGpsPositionListener : public rclcpp::Node
 public:
 	explicit VehicleGpsPositionListener() : Node("vehicle_global_position_listener")
 	{
-		subscription_ = this->create_subscription<px4_msgs::msg::SensorGps>("/fmu/out/vehicle_gps_position", 10,
+		rmw_qos_profile_t qos_profile = rmw_qos_profile_sensor_data;
+		auto qos = rclcpp::QoS(rclcpp::QoSInitialization(qos_profile.history, 5), qos_profile);
+		
+		subscription_ = this->create_subscription<px4_msgs::msg::SensorGps>("/fmu/out/vehicle_gps_position", qos,
 		[this](const px4_msgs::msg::SensorGps::UniquePtr msg) {
 			std::cout << "\n\n\n\n\n\n\n\n\n\n";
 			std::cout << "RECEIVED VEHICLE GPS POSITION DATA"   << std::endl;


### PR DESCRIPTION
## What

I've specified the QoS profiles in both subscribers in the example listeners scripts.

## Why

Both nodes could subscribe to the respective topics but they didn't see and output anything due to the mismatch of the QoS profiles between publishers and subscribers.

Signed-off-by: Marco <marco98.bonazza@yahoo.it>