### PR TITLE
sensor_combined_listener - output to screen disable microros

### DIFF
--- a/launch/sensor_combined_listener.launch.py
+++ b/launch/sensor_combined_listener.launch.py
@@ -52,10 +52,11 @@ def generate_launch_description():
     sensor_combined_listener_node = Node(
         package='px4_ros_com',
         executable='sensor_combined_listener',
-        shell=True
+        output='screen'
+        shell=True,
     )
 
     return LaunchDescription([
-        micro_ros_agent,
+        #micro_ros_agent,
         sensor_combined_listener_node
     ])


### PR DESCRIPTION
The sensor_combined_listener is a good example of how to listen to events from PX4 and is used in the docs. 

This change modifies the launch file to 
- output to screen, rather than the default which is to log. 
- disables, but does not remove starting the microROS agent.

The first change is needed because this example is supposed to show data from a uorb topic and if you don't display it you have to know enough about ROS to find the log. Further, the docs for example show it outputs to screen, and the other launch files output to screen.

The microROS agent auto starting assumes you are using that agent and not XRCE-DDS, and that it is in the environment you're using. Those are both unnecessary constraints which result in error message if not true. For example, for me when I use XRCE-DDS agent.
I think it is useful to show that you can do this though, so have not removed the code, just disabled starting it. 

@beniaminopozzan @dagar Can we merge this. Also need https://github.com/PX4/px4_ros_com/pull/174 merged for docs.