### PR TITLE
offboard_control.cpp - TrajectorySetpoint message changed ages ago

### DIFF
--- a/src/examples/offboard/offboard_control.cpp
+++ b/src/examples/offboard/offboard_control.cpp
@@ -36,11 +36,6 @@
  * @addtogroup examples
  * @author Mickey Cowden <info@cowden.tech>
  * @author Nuno Marques <nuno.marques@dronesolutions.io>
-
- * The TrajectorySetpoint message and the OFFBOARD mode in general are under an ongoing update.
- * Please refer to PR: https://github.com/PX4/PX4-Autopilot/pull/16739 for more info.
- * As per PR: https://github.com/PX4/PX4-Autopilot/pull/17094, the format
- * of the TrajectorySetpoint message shall change.
  */
 
 #include <px4_msgs/msg/offboard_control_mode.hpp>


### PR DESCRIPTION
Removes comment about TrajectorySetpoint  changing in future. This change happened ages ago. If there were any relevant changes in this example, they have not changed the values that are written or its behaviour.