### PR TITLE
Error launch file: Miss comma on file

### DIFF
--- a/launch/sensor_combined_listener.launch.py
+++ b/launch/sensor_combined_listener.launch.py
@@ -52,7 +52,7 @@ def generate_launch_description():
     sensor_combined_listener_node = Node(
         package='px4_ros_com',
         executable='sensor_combined_listener',
-        output='screen'
+        output='screen',
         shell=True,
     )
 


### PR DESCRIPTION
In the last edit, the last person missed to add a comma in line 55.  It causes an error when someone tried to run this launch file:
```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: invalid syntax. Perhaps you forgot a comma? (sensor_combined_listener.launch.py, line 55)
```
I fixed it to add comma at line 55

Signed-off-by: federicociresola <federicociresola@github.com>