### PR TITLE
Update gps listener to match the SensorGps update with RTK precision

### DIFF
--- a/src/examples/listeners/vehicle_gps_position_listener.cpp
+++ b/src/examples/listeners/vehicle_gps_position_listener.cpp
@@ -57,10 +57,10 @@ public:
 			std::cout << "RECEIVED VEHICLE GPS POSITION DATA"   << std::endl;
 			std::cout << "=================================="   << std::endl;
 			std::cout << "ts: "      << msg->timestamp    << std::endl;
-			std::cout << "lat: " << msg->lat  << std::endl;
-			std::cout << "lon: " << msg->lon << std::endl;
-			std::cout << "alt: " << msg->alt  << std::endl;
-			std::cout << "alt_ellipsoid: " << msg->alt_ellipsoid << std::endl;
+			std::cout << "lat: " << msg->latitude_deg  << std::endl;
+			std::cout << "lon: " << msg->longitude_deg << std::endl;
+			std::cout << "alt: " << msg->altitude_msl_m  << std::endl;
+			std::cout << "alt_ellipsoid: " << msg->altitude_ellipsoid_m << std::endl;
 			std::cout << "s_variance_m_s: " << msg->s_variance_m_s << std::endl;
 			std::cout << "c_variance_rad: " << msg->c_variance_rad << std::endl;
 			std::cout << "fix_type: " << msg->fix_type << std::endl;


### PR DESCRIPTION
Previously there was a build issue related to the latest `px4_msgs`:

```
/ws/src/px4_ros_com/src/examples/listeners/vehicle_gps_position_listener.cpp: In lambda function:
/ws/src/px4_ros_com/src/examples/listeners/vehicle_gps_position_listener.cpp:60:54: error: ‘struct px4_msgs::msg::SensorGps_<std::allocator<void> >’ has no member named ‘lat’
   60 |                         std::cout << "lat: " << msg->lat  << std::endl;
      |                                                      ^~~
/ws/src/px4_ros_com/src/examples/listeners/vehicle_gps_position_listener.cpp:61:54: error: ‘struct px4_msgs::msg::SensorGps_<std::allocator<void> >’ has no member named ‘lon’
   61 |                         std::cout << "lon: " << msg->lon << std::endl;
      |                                                      ^~~
/ws/src/px4_ros_com/src/examples/listeners/vehicle_gps_position_listener.cpp:62:54: error: ‘struct px4_msgs::msg::SensorGps_<std::allocator<void> >’ has no member named ‘alt’
   62 |                         std::cout << "alt: " << msg->alt  << std::endl;
      |                                                      ^~~
/ws/src/px4_ros_com/src/examples/listeners/vehicle_gps_position_listener.cpp:63:64: error: ‘struct px4_msgs::msg::SensorGps_<std::allocator<void> >’ has no member named ‘alt_ellipsoid’; did you mean ‘altitude_ellipsoid_m’?
   63 |                         std::cout << "alt_ellipsoid: " << msg->alt_ellipsoid << std::endl;
```

This fixes the issue by updating the cout to work with the updated message definition.