### PR TITLE
Fix Python offboard control breakage due to PX4 v1.16 topic rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,19 +3,21 @@ project(px4_ros_com)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
-	set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_STANDARD 99)
 endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-	set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 14)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
+########################
+# Find ROS dependencies #
+########################
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
@@ -32,14 +34,13 @@ find_package(rclpy REQUIRED)
 
 include_directories(include)
 
-# Add frame_transforms lib
+# frame_transforms shared library
 add_library(frame_transforms SHARED src/lib/frame_transforms.cpp)
 ament_target_dependencies(frame_transforms Eigen3 geometry_msgs sensor_msgs)
 target_include_directories(frame_transforms PUBLIC
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
-	$<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-
 
 # examples/listeners/sensor_combined_listener
 add_executable(sensor_combined_listener src/examples/listeners/sensor_combined_listener.cpp)
@@ -56,7 +57,7 @@ add_executable(debug_vect_advertiser src/examples/advertisers/debug_vect_adverti
 ament_target_dependencies(debug_vect_advertiser rclcpp px4_msgs)
 install(TARGETS debug_vect_advertiser DESTINATION lib/${PROJECT_NAME})
 
-# examples/offboard/offboard_control
+# examples/offboard/offboard_control (C++)
 add_executable(offboard_control src/examples/offboard/offboard_control.cpp)
 ament_target_dependencies(offboard_control rclcpp px4_msgs)
 install(TARGETS offboard_control DESTINATION lib/${PROJECT_NAME})
@@ -66,63 +67,65 @@ add_executable(offboard_control_srv src/examples/offboard/offboard_control_srv.c
 ament_target_dependencies(offboard_control_srv rclcpp px4_msgs)
 install(TARGETS offboard_control_srv DESTINATION lib/${PROJECT_NAME})
 
-
 ############
 # Install ##
 ############
 
-# Export information to downstream packages
-ament_export_dependencies(ament_cmake rclcpp rosidl_default_runtime eigen3_cmake_module Eigen3 px4_msgs geometry_msgs sensor_msgs)
+# Export info to downstream packages
+ament_export_dependencies(
+  ament_cmake
+  rclcpp
+  rosidl_default_runtime
+  eigen3_cmake_module
+  Eigen3
+  px4_msgs
+  geometry_msgs
+  sensor_msgs
+)
 
 ament_export_targets(export_frame_transforms HAS_LIBRARY_TARGET)
-
 ament_export_include_directories(include)
 ament_export_libraries(frame_transforms)
 
 # Install header files
 install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION include/${PROJECT_NAME})
 
+# Install the shared library
 install(TARGETS frame_transforms
-	EXPORT export_frame_transforms
-	ARCHIVE DESTINATION lib
-	LIBRARY DESTINATION lib
-	RUNTIME DESTINATION bin
-	INCLUDES DESTINATION include
+  EXPORT export_frame_transforms
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
 )
 
-# Install launch files.
+# Install launch files
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
 
 # Install tests
 install(DIRECTORY test DESTINATION share/${PROJECT_NAME}/)
 
-
 ############
 # Testing ##
 ############
-
 if(BUILD_TESTING)
-	find_package(ament_lint_auto REQUIRED)
-	# the following line skips the linter which checks for copyrights
-	# uncomment the line when a copyright and license is not present in all source files
-	#set(ament_cmake_copyright_FOUND TRUE)
-	# the following line skips cpplint (only works in a git repo)
-	# uncomment the line when this package is not in a git repo
-	#set(ament_cmake_cpplint_FOUND TRUE)
-	ament_lint_auto_find_test_dependencies()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 endif()
 
 ###########
 # Python ##
 ###########
 
-# Install Python modules
+# Install Python modules in px4_ros_com/ (the Python package folder)
 ament_python_install_package(${PROJECT_NAME})
 
-# Install Python executables
+# Install Python executable with a non-conflicting name
+# (requires the script to have a shebang and executable bit)
 install(PROGRAMS
   src/examples/offboard_py/offboard_control.py
   DESTINATION lib/${PROJECT_NAME}
+  RENAME offboard_control_py
 )
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,21 +3,19 @@ project(px4_ros_com)
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
+	set(CMAKE_C_STANDARD 99)
 endif()
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+	set(CMAKE_CXX_STANDARD 14)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+	add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-########################
-# Find ROS dependencies #
-########################
+# find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
@@ -34,13 +32,14 @@ find_package(rclpy REQUIRED)
 
 include_directories(include)
 
-# frame_transforms shared library
+# Add frame_transforms lib
 add_library(frame_transforms SHARED src/lib/frame_transforms.cpp)
 ament_target_dependencies(frame_transforms Eigen3 geometry_msgs sensor_msgs)
 target_include_directories(frame_transforms PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
-  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME}>
+	$<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
+
 
 # examples/listeners/sensor_combined_listener
 add_executable(sensor_combined_listener src/examples/listeners/sensor_combined_listener.cpp)
@@ -57,7 +56,7 @@ add_executable(debug_vect_advertiser src/examples/advertisers/debug_vect_adverti
 ament_target_dependencies(debug_vect_advertiser rclcpp px4_msgs)
 install(TARGETS debug_vect_advertiser DESTINATION lib/${PROJECT_NAME})
 
-# examples/offboard/offboard_control (C++)
+# examples/offboard/offboard_control
 add_executable(offboard_control src/examples/offboard/offboard_control.cpp)
 ament_target_dependencies(offboard_control rclcpp px4_msgs)
 install(TARGETS offboard_control DESTINATION lib/${PROJECT_NAME})
@@ -67,50 +66,50 @@ add_executable(offboard_control_srv src/examples/offboard/offboard_control_srv.c
 ament_target_dependencies(offboard_control_srv rclcpp px4_msgs)
 install(TARGETS offboard_control_srv DESTINATION lib/${PROJECT_NAME})
 
+
 ############
 # Install ##
 ############
 
-# Export info to downstream packages
-ament_export_dependencies(
-  ament_cmake
-  rclcpp
-  rosidl_default_runtime
-  eigen3_cmake_module
-  Eigen3
-  px4_msgs
-  geometry_msgs
-  sensor_msgs
-)
+# Export information to downstream packages
+ament_export_dependencies(ament_cmake rclcpp rosidl_default_runtime eigen3_cmake_module Eigen3 px4_msgs geometry_msgs sensor_msgs)
 
 ament_export_targets(export_frame_transforms HAS_LIBRARY_TARGET)
+
 ament_export_include_directories(include)
 ament_export_libraries(frame_transforms)
 
 # Install header files
 install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION include/${PROJECT_NAME})
 
-# Install the shared library
 install(TARGETS frame_transforms
-  EXPORT export_frame_transforms
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
+	EXPORT export_frame_transforms
+	ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION lib
+	RUNTIME DESTINATION bin
+	INCLUDES DESTINATION include
 )
 
-# Install launch files
+# Install launch files.
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
 
 # Install tests
 install(DIRECTORY test DESTINATION share/${PROJECT_NAME}/)
 
+
 ############
 # Testing ##
 ############
+
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
+	find_package(ament_lint_auto REQUIRED)
+	# the following line skips the linter which checks for copyrights
+	# uncomment the line when a copyright and license is not present in all source files
+	#set(ament_cmake_copyright_FOUND TRUE)
+	# the following line skips cpplint (only works in a git repo)
+	# uncomment the line when this package is not in a git repo
+	#set(ament_cmake_cpplint_FOUND TRUE)
+	ament_lint_auto_find_test_dependencies()
 endif()
 
 ###########

--- a/src/examples/offboard_py/offboard_control.py
+++ b/src/examples/offboard_py/offboard_control.py
@@ -32,7 +32,7 @@ class OffboardControl(Node):
         self.vehicle_local_position_subscriber = self.create_subscription(
             VehicleLocalPosition, '/fmu/out/vehicle_local_position', self.vehicle_local_position_callback, qos_profile)
         self.vehicle_status_subscriber = self.create_subscription(
-            VehicleStatus, '/fmu/out/vehicle_status', self.vehicle_status_callback, qos_profile)
+            VehicleStatus, '/fmu/out/vehicle_status_v1', self.vehicle_status_callback, qos_profile)
 
         # Initialize variables
         self.offboard_setpoint_counter = 0


### PR DESCRIPTION
    Fix Python offboard control breakage due to PX4 v1.16 topic rename
    
    PX4 v1.16 renames the `vehicle_status` uORB/ROS topic to
    `vehicle_status_v1`. The original version of this fork still subscribes
    to the old topic, which causes the Python offboard_control node to fail
    silently and prevents offboard mode from functioning correctly in SITL.
    
    This commit updates the Python node to use `vehicle_status_v1`, restoring
    correct offboard behavior. It also renames the installed Python executable
    to `offboard_control_py` to allow clean invocation via:
    
      ros2 run px4_ros_com offboard_control_py